### PR TITLE
exit with non zero on error

### DIFF
--- a/cmd/goverter/main.go
+++ b/cmd/goverter/main.go
@@ -34,6 +34,6 @@ func main() {
 	})
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
-		return
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This is to correctly handle `go generate` calls in build pipelines.