### PR TITLE
map nil slice to nil

### DIFF
--- a/builder/list.go
+++ b/builder/list.go
@@ -33,7 +33,10 @@ func (*List) Build(gen Generator, ctx *MethodContext, sourceID *xtype.JenID, sou
 	newStmt = append(newStmt, jen.Id(targetSlice).Index(jen.Id(index)).Op("=").Add(newID.Code))
 
 	stmt := []jen.Code{
-		jen.Id(targetSlice).Op(":=").Make(target.TypeAsJen(), jen.Len(sourceID.Code.Clone())),
+		jen.Var().Add(jen.Id(targetSlice), target.TypeAsJen()),
+		jen.If(sourceID.Code.Clone().Op("!=").Nil()).Block(
+			jen.Id(targetSlice).Op("=").Make(target.TypeAsJen(), jen.Len(sourceID.Code.Clone()), jen.Len(sourceID.Code.Clone())),
+		),
 		jen.For(jen.Id(index).Op(":=").Lit(0), jen.Id(index).Op("<").Len(sourceID.Code.Clone()), jen.Id(index).Op("++")).
 			Block(newStmt...),
 	}

--- a/scenario/3_struct_identity_mapping_pointer_error_wrapping.yml
+++ b/scenario/3_struct_identity_mapping_pointer_error_wrapping.yml
@@ -45,7 +45,10 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) Convert(source []execution.Person) ([]execution.APIPerson, error) {
-    	structsAPIPersonList := make([]execution.APIPerson, len(source))
+    	var structsAPIPersonList []execution.APIPerson
+    	if source != nil {
+    		structsAPIPersonList = make([]execution.APIPerson, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		structsAPIPerson, err := c.ConvertPerson(source[i])
     		if err != nil {

--- a/scenario/3_struct_mapping_extend_with_converter.yml
+++ b/scenario/3_struct_mapping_extend_with_converter.yml
@@ -45,14 +45,20 @@ success: |
     	return pStructsOutput
     }
     func (c *ConverterImpl) ConvertCats(source []execution.Cat) []execution.Animal {
-    	structsAnimalList := make([]execution.Animal, len(source))
+    	var structsAnimalList []execution.Animal
+    	if source != nil {
+    		structsAnimalList = make([]execution.Animal, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		structsAnimalList[i] = c.structsCatToStructsAnimal(source[i])
     	}
     	return structsAnimalList
     }
     func (c *ConverterImpl) ConvertDogs(source []execution.Dog) []execution.Animal {
-    	structsAnimalList := make([]execution.Animal, len(source))
+    	var structsAnimalList []execution.Animal
+    	if source != nil {
+    		structsAnimalList = make([]execution.Animal, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		structsAnimalList[i] = c.structsDogToStructsAnimal(source[i])
     	}

--- a/scenario/4_pointer_slice.yml
+++ b/scenario/4_pointer_slice.yml
@@ -28,7 +28,10 @@ success: |
     	var pStringList *[]string
     	if source.Names != nil {
     		stringListSourceDeref := *source.Names
-    		stringList := make([]string, len(stringListSourceDeref))
+    		var stringList []string
+    		if stringListSourceDeref != nil {
+    			stringList = make([]string, len(stringListSourceDeref), len(stringListSourceDeref))
+    		}
     		for i := 0; i < len(stringListSourceDeref); i++ {
     			stringList[i] = stringListSourceDeref[i]
     		}

--- a/scenario/4_slice_array.yml
+++ b/scenario/4_slice_array.yml
@@ -14,7 +14,7 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) Convert(source [5]int) []int {
-    	intList := make([]int, len(source))
+    	intList := make([]int, len(source), len(source))
     	for i := 0; i < len(source); i++ {
     		intList[i] = source[i]
     	}

--- a/scenario/4_slice_named.yml
+++ b/scenario/4_slice_named.yml
@@ -25,49 +25,70 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) Convert(source []execution.ID) []int {
-    	intList := make([]int, len(source))
+    	var intList []int
+    	if source != nil {
+    		intList = make([]int, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		intList[i] = int(source[i])
     	}
     	return intList
     }
     func (c *ConverterImpl) Convert2(source execution.IDs) []int {
-    	intList := make([]int, len(source))
+    	var intList []int
+    	if source != nil {
+    		intList = make([]int, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		intList[i] = source[i]
     	}
     	return intList
     }
     func (c *ConverterImpl) Convert3(source execution.IDs) execution.IDs {
-    	slicesIDs := make(execution.IDs, len(source))
+    	var slicesIDs execution.IDs
+    	if source != nil {
+    		slicesIDs = make(execution.IDs, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		slicesIDs[i] = source[i]
     	}
     	return slicesIDs
     }
     func (c *ConverterImpl) Convert4(source []execution.ID) execution.IDs {
-    	slicesIDs := make(execution.IDs, len(source))
+    	var slicesIDs execution.IDs
+    	if source != nil {
+    		slicesIDs = make(execution.IDs, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		slicesIDs[i] = int(source[i])
     	}
     	return slicesIDs
     }
     func (c *ConverterImpl) Convert5(source execution.IIDs) execution.IDs {
-    	slicesIDs := make(execution.IDs, len(source))
+    	var slicesIDs execution.IDs
+    	if source != nil {
+    		slicesIDs = make(execution.IDs, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		slicesIDs[i] = int(source[i])
     	}
     	return slicesIDs
     }
     func (c *ConverterImpl) Convert6(source []int) execution.IIDs {
-    	slicesIIDs := make(execution.IIDs, len(source))
+    	var slicesIIDs execution.IIDs
+    	if source != nil {
+    		slicesIIDs = make(execution.IIDs, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		slicesIIDs[i] = execution.ID(source[i])
     	}
     	return slicesIIDs
     }
     func (c *ConverterImpl) Convert7(source []int) execution.IDs {
-    	slicesIDs := make(execution.IDs, len(source))
+    	var slicesIDs execution.IDs
+    	if source != nil {
+    		slicesIDs = make(execution.IDs, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		slicesIDs[i] = source[i]
     	}

--- a/scenario/4_slice_nested.yml
+++ b/scenario/4_slice_nested.yml
@@ -14,11 +14,20 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) Convert(source [][][]int) [][][]int {
-    	intListListList := make([][][]int, len(source))
+    	var intListListList [][][]int
+    	if source != nil {
+    		intListListList = make([][][]int, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
-    		intListList := make([][]int, len(source[i]))
+    		var intListList [][]int
+    		if source[i] != nil {
+    			intListList = make([][]int, len(source[i]), len(source[i]))
+    		}
     		for j := 0; j < len(source[i]); j++ {
-    			intList := make([]int, len(source[i][j]))
+    			var intList []int
+    			if source[i][j] != nil {
+    				intList = make([]int, len(source[i][j]), len(source[i][j]))
+    			}
     			for k := 0; k < len(source[i][j]); k++ {
     				intList[k] = source[i][j][k]
     			}

--- a/scenario/4_slice_primitive.yml
+++ b/scenario/4_slice_primitive.yml
@@ -14,7 +14,10 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) Convert(source []int) []int {
-    	intList := make([]int, len(source))
+    	var intList []int
+    	if source != nil {
+    		intList = make([]int, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		intList[i] = source[i]
     	}

--- a/scenario/4_slice_primitive_pointer.yml
+++ b/scenario/4_slice_primitive_pointer.yml
@@ -15,7 +15,10 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) ConvertPToP(source []*int) []*int {
-    	pIntList := make([]*int, len(source))
+    	var pIntList []*int
+    	if source != nil {
+    		pIntList = make([]*int, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		var pInt *int
     		if source[i] != nil {
@@ -27,7 +30,10 @@ success: |
     	return pIntList
     }
     func (c *ConverterImpl) ConvertToP(source []int) []*int {
-    	pIntList := make([]*int, len(source))
+    	var pIntList []*int
+    	if source != nil {
+    		pIntList = make([]*int, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		pInt := source[i]
     		pIntList[i] = &pInt

--- a/scenario/4_slice_primitive_wrap_errors.yml
+++ b/scenario/4_slice_primitive_wrap_errors.yml
@@ -21,7 +21,10 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) Convert(source []string) ([]int, error) {
-    	intList := make([]int, len(source))
+    	var intList []int
+    	if source != nil {
+    		intList = make([]int, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		xint, err := strconv.Atoi(source[i])
     		if err != nil {

--- a/scenario/4_slice_primitive_wrap_errors_via_method_tag.yml
+++ b/scenario/4_slice_primitive_wrap_errors_via_method_tag.yml
@@ -21,7 +21,10 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) Convert(source []string) ([]int, error) {
-    	intList := make([]int, len(source))
+    	var intList []int
+    	if source != nil {
+    		intList = make([]int, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		xint, err := strconv.Atoi(source[i])
     		if err != nil {

--- a/scenario/4_slice_struct.yml
+++ b/scenario/4_slice_struct.yml
@@ -25,7 +25,10 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) Convert(source []execution.Input) []execution.Output {
-    	slicesOutputList := make([]execution.Output, len(source))
+    	var slicesOutputList []execution.Output
+    	if source != nil {
+    		slicesOutputList = make([]execution.Output, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		slicesOutputList[i] = c.slicesInputToSlicesOutput(source[i])
     	}

--- a/scenario/4_slice_struct_pointer.yml
+++ b/scenario/4_slice_struct_pointer.yml
@@ -26,14 +26,20 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) ConvertP(source []execution.Input) []*execution.Output {
-    	pSlicesOutputList := make([]*execution.Output, len(source))
+    	var pSlicesOutputList []*execution.Output
+    	if source != nil {
+    		pSlicesOutputList = make([]*execution.Output, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		pSlicesOutputList[i] = c.slicesInputToPSlicesOutput(source[i])
     	}
     	return pSlicesOutputList
     }
     func (c *ConverterImpl) ConvertPToP(source []*execution.Input) []*execution.Output {
-    	pSlicesOutputList := make([]*execution.Output, len(source))
+    	var pSlicesOutputList []*execution.Output
+    	if source != nil {
+    		pSlicesOutputList = make([]*execution.Output, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		var pSlicesOutput *execution.Output
     		if source[i] != nil {

--- a/scenario/6_return_propergate_error.yml
+++ b/scenario/6_return_propergate_error.yml
@@ -26,7 +26,10 @@ success: |
     type ConverterImpl struct{}
 
     func (c *ConverterImpl) Convert(source []execution.Input) ([]execution.Output, error) {
-    	slicesOutputList := make([]execution.Output, len(source))
+    	var slicesOutputList []execution.Output
+    	if source != nil {
+    		slicesOutputList = make([]execution.Output, len(source), len(source))
+    	}
     	for i := 0; i < len(source); i++ {
     		slicesOutput, err := c.slicesInputToSlicesOutput(source[i])
     		if err != nil {


### PR DESCRIPTION
In our usecase, nil slice is not the same as empty slice. This patch maps nil slices to nil.

This changes may affect users who depended on the older behavior that converts nil slices to empty slices. For example, encoding a nil slice in a JSON response will be `null` but empty slice will be `[]`. So users who don't tolerate this in their code flow may be affected.

I suggest to enable this behavior on-demand, but couldn't resolve a possible solution.