### PR TITLE
add sub context to support combining nested automap and rename

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -35,6 +35,7 @@ type Generator interface {
 type MethodContext struct {
 	*namer.Namer
 	Fields       map[string]*FieldMapping
+	SubFields    map[string]*FieldMapping
 	FieldsTarget string
 	Signature    xtype.Signature
 	TargetType   *xtype.Type

--- a/builder/struct.go
+++ b/builder/struct.go
@@ -69,7 +69,26 @@ func (*Struct) Build(gen Generator, ctx *MethodContext, sourceID *xtype.JenID, s
 			}
 			stmt = append(stmt, mapStmt...)
 
-			fieldStmt, fieldID, err := gen.Build(ctx, xtype.VariableID(nextID), nextSource, targetFieldType, errWrapper)
+			subFields := map[string]*FieldMapping{}
+			for k, prop := range ctx.Fields {
+				if strings.HasPrefix(k, targetField.Name()+".") {
+					subFields[k[len(targetField.Name())+1:]] = prop
+				}
+			}
+			subCtx := &MethodContext{
+				Namer:        ctx.Namer,
+				Fields:       ctx.Fields,
+				SubFields:    subFields,
+				FieldsTarget: ctx.FieldsTarget,
+				Signature:    ctx.Signature,
+				TargetType:   ctx.TargetType,
+				AutoMap:      ctx.AutoMap,
+				Flags:        ctx.Flags,
+				SeenNamed:    ctx.SeenNamed,
+				TargetVar:    ctx.TargetVar,
+			}
+
+			fieldStmt, fieldID, err := gen.Build(subCtx, xtype.VariableID(nextID), nextSource, targetFieldType, errWrapper)
 			if err != nil {
 				return nil, nil, err.Lift(lift...)
 			}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -434,7 +434,7 @@ func (g *generator) Build(
 			Name:   name,
 			Source: xtype.TypeOf(source.T),
 			Target: xtype.TypeOf(target.T),
-			Fields: map[string]*builder.FieldMapping{},
+			Fields: ctx.SubFields,
 			Flags:  g.flags,
 			Call:   jen.Id(xtype.ThisVar).Dot(name),
 		}


### PR DESCRIPTION
**When I Combine automap and fieldmap, it doesn't work**

```golang
// goverter:converter
type Converter interface {
	// goverter:map . Address
	// goverter:map Street Address.StreetName
	Convert(FlatPerson) Person
}

type FlatPerson struct {
	Name    string
	Age     int
	Street  string
	ZipCode string
}

type Person struct {
	Name string
	Age  int
	Address
}
type Address struct {
	StreetName string
	ZipCode    string
}
```
the error message was as follows

```text
| github.com/jmattheis/goverter/example/nested.FlatPerson
|
|      | goverter:map . Address
|      |
|      |
|      |
source.       .???
target.Address.StreetName
|      |       |
|      |       | string
|      |
|      | github.com/jmattheis/goverter/example/nested.Address
|
| github.com/jmattheis/goverter/example/nested.Person

Cannot match the target field with the source entry: "StreetName" does not exist.
```

**The solution might be to add the sub context when createing subMethod**

It works fine.
```golang
package generated

import nested "github.com/jmattheis/goverter/example/nested"

type ConverterImpl struct{}

func (c *ConverterImpl) Convert(source nested.FlatPerson) nested.Person {
	var nestedPerson nested.Person
	nestedPerson.Name = source.Name
	nestedPerson.Age = source.Age
	nestedPerson.Address = c.nestedFlatPersonToNestedAddress(source)
	return nestedPerson
}
func (c *ConverterImpl) nestedFlatPersonToNestedAddress(source nested.FlatPerson) nested.Address {
	var nestedAddress nested.Address
	nestedAddress.StreetName = source.Street
	nestedAddress.ZipCode = source.ZipCode
	return nestedAddress
}
```

**It works fine, too, and even handles nested cases.  But I don't know if there are other problems**
```golang
// goverter:converter
type Converter interface {
	// goverter:map . Address
	// goverter:map . Address.StreetInfo
	// goverter:map Street Address.StreetInfo.Name
	Convert(FlatPerson) Person
}

type FlatPerson struct {
	Name    string
	Age     int
	Street  string
	ZipCode string
}

type Person struct {
	Name string
	Age  int
	Address
}
type Address struct {
	StreetInfo
	ZipCode string
}
type StreetInfo struct {
	Name string
}
```

generated
```golang
package generated

import nested "github.com/jmattheis/goverter/example/nested"

type ConverterImpl struct{}

func (c *ConverterImpl) Convert(source nested.FlatPerson) nested.Person {
	var nestedPerson nested.Person
	nestedPerson.Name = source.Name
	nestedPerson.Age = source.Age
	nestedPerson.Address = c.nestedFlatPersonToNestedAddress(source)
	return nestedPerson
}
func (c *ConverterImpl) nestedFlatPersonToNestedAddress(source nested.FlatPerson) nested.Address {
	var nestedAddress nested.Address
	nestedAddress.StreetInfo = c.nestedFlatPersonToNestedStreetInfo(source)
	nestedAddress.ZipCode = source.ZipCode
	return nestedAddress
}
func (c *ConverterImpl) nestedFlatPersonToNestedStreetInfo(source nested.FlatPerson) nested.StreetInfo {
	var nestedStreetInfo nested.StreetInfo
	nestedStreetInfo.Name = source.Street
	return nestedStreetInfo
}
```
