### PR TITLE
feat(comment): add comment flag

### DIFF
--- a/cmd/goverter/main.go
+++ b/cmd/goverter/main.go
@@ -14,6 +14,7 @@ func main() {
 	output := flag.String("output", "./generated/generated.go", "")
 	extends := flag.String("extends", "", "comma separated list of local or package extends")
 	packagePath := flag.String("packagePath", "", "optional full package path for the generated code")
+	commentOnStruct := flag.String("commentOnStruct", "", "optional comment on the generated struct")
 	wrapErrors := flag.Bool("wrapErrors", false,
 		"if set, wrap conversion errors with extra details, such as struct field names")
 	ignoreUnexportedFields := flag.Bool("ignoreUnexportedFields", false,
@@ -42,6 +43,7 @@ func main() {
 		WrapErrors:              *wrapErrors,
 		IgnoredUnexportedFields: *ignoreUnexportedFields,
 		MatchFieldsIgnoreCase:   *matchFieldsIgnoreCase,
+		CommentOnStruct:         *commentOnStruct,
 	})
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)

--- a/generator/generate.go
+++ b/generator/generate.go
@@ -20,6 +20,7 @@ type Config struct {
 	WrapErrors             bool
 	IgnoreUnexportedFields bool
 	MatchFieldsIgnoreCase  bool
+	CommentOnStruct        string
 }
 
 // BuildSteps that'll used for generation.
@@ -45,6 +46,8 @@ func Generate(pattern string, mapping []comments.Converter, config Config) (*jen
 		if obj == nil {
 			return nil, fmt.Errorf("%s: could not find %s", pattern, converter.Name)
 		}
+
+		file.Comment(config.CommentOnStruct)
 
 		// create the converter struct
 		file.Type().Id(converter.Config.Name).Struct()

--- a/runner.go
+++ b/runner.go
@@ -33,6 +33,8 @@ type GenerateConfig struct {
 	IgnoredUnexportedFields bool
 	// MatchFieldsIgnoreCase tells goverter to use case insensitive match everywhere.
 	MatchFieldsIgnoreCase bool
+	// Add comment on generated structs
+	CommentOnStruct string
 }
 
 // GenerateConverter generates converters.
@@ -53,6 +55,7 @@ func GenerateConverter(c GenerateConfig) ([]byte, error) {
 		WrapErrors:             c.WrapErrors,
 		IgnoreUnexportedFields: c.IgnoredUnexportedFields,
 		MatchFieldsIgnoreCase:  c.MatchFieldsIgnoreCase,
+		CommentOnStruct:        c.CommentOnStruct,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What I did.
This pull request introduces a new feature to the Goverter library: the -commentOnStruct flag. This feature allows users to add comments above generated structs, which can be especially useful when working with other code generation tools like Autowire.

### Changes Made
I have introduced a new command-line flag, -commentOnStruct, which, when enabled, will add a comment above each generated struct. These comments can provide valuable information about the struct's purpose, source, or usage.

Example Usage
```bash
goverter -commentOnStruct "// @autowire(set=converter)" <otherFlag> <path>
```
result
```go
// @autowire(set=converter)
type ConverterImpl struct{}
```