### PR TITLE
fix: remove empty lines from errors

### DIFF
--- a/builder/error.go
+++ b/builder/error.go
@@ -16,8 +16,6 @@ type Path struct {
 	TargetType string
 }
 
-const pipe = '|'
-
 // Error defines a conversion error.
 type Error struct {
 	Path  []*Path
@@ -41,63 +39,68 @@ func ToString(err *Error) string {
 		panic("oops that shouldn't happen")
 	}
 
-	end := 2 + (len(err.Path) * 4) - 1
-	sourcePath := (len(err.Path) * 2)
-	targetPath := sourcePath + 1
+	sourcePaths := 0
+	targetPaths := 0
+	for _, path := range err.Path {
+		if path.SourceType != "" {
+			sourcePaths++
+		}
+		if path.TargetType != "" {
+			targetPaths++
+		}
+	}
 
-	matrix := make([][]rune, end+1)
+	end := 2 + (sourcePaths+targetPaths)*2 - 1
+	sourceLine := (sourcePaths * 2)
+	targetLine := sourceLine + 1
 
+	lines := make([]string, end+1)
+
+	sourceTypeLine := 0
+	targetTypeLine := end
 	for i := 0; i < len(err.Path); i++ {
 		path := err.Path[i]
 		padding := int(math.Max(float64(len(path.SourceID)), float64(len(path.TargetID))))
 
-		sourceIdx := i * 2
 		if path.SourceType != "" {
-			matrix[sourceIdx] = append(matrix[sourceIdx], []rune(strings.Repeat(" ", len(path.Prefix)))...)
-			matrix[sourceIdx] = append(matrix[sourceIdx], pipe, ' ')
-			matrix[sourceIdx] = append(matrix[sourceIdx], []rune(path.SourceType)...)
+			lines[sourceTypeLine] += space(len(path.Prefix)) + "| " + path.SourceType
 
-			for j := sourceIdx + 1; j < sourcePath; j++ {
-				matrix[j] = append(matrix[j], []rune(strings.Repeat(" ", len(path.Prefix)))...)
-				matrix[j] = append(matrix[j], pipe)
-				matrix[j] = append(matrix[j], []rune(strings.Repeat(" ", padding-1))...)
+			for j := sourceTypeLine + 1; j < sourceLine; j++ {
+				lines[j] += space(len(path.Prefix)) + "|" + space(padding-1)
 			}
+			sourceTypeLine += 2
 		} else {
-			for j := sourceIdx + 1; j < sourcePath; j++ {
-				matrix[j] = append(matrix[j], []rune(strings.Repeat(" ", padding+len(path.Prefix)))...)
+			for j := sourceTypeLine; j < sourceLine; j++ {
+				lines[j] += space(len(path.Prefix) + padding)
 			}
 		}
 
-		matrix[sourcePath] = append(matrix[sourcePath], []rune(path.Prefix)...)
-		matrix[sourcePath] = append(matrix[sourcePath], []rune(path.SourceID)...)
-		matrix[sourcePath] = append(matrix[sourcePath], []rune(strings.Repeat(" ", padding-len(path.SourceID)))...)
+		lines[sourceLine] += path.Prefix + path.SourceID + space(padding-len(path.SourceID))
 
-		targetIdx := end - (i * 2)
 		if path.TargetType != "" {
-			matrix[targetPath] = append(matrix[targetPath], []rune(path.Prefix)...)
-			matrix[targetPath] = append(matrix[targetPath], []rune(path.TargetID)...)
-			matrix[targetPath] = append(matrix[targetPath], []rune(strings.Repeat(" ", padding-len(path.TargetID)))...)
+			lines[targetLine] += path.Prefix + path.TargetID + space(padding-len(path.TargetID))
 
-			for j := targetIdx - 1; j > targetPath; j-- {
-				matrix[j] = append(matrix[j], []rune(strings.Repeat(" ", len(path.Prefix)))...)
-				matrix[j] = append(matrix[j], pipe)
-				matrix[j] = append(matrix[j], []rune(strings.Repeat(" ", padding-1))...)
+			for j := targetTypeLine - 1; j > targetLine; j-- {
+				lines[j] += space(len(path.Prefix)) + "|" + space(padding-1)
 			}
-			matrix[targetIdx] = append(matrix[targetIdx], []rune(strings.Repeat(" ", len(path.Prefix)))...)
-			matrix[targetIdx] = append(matrix[targetIdx], pipe, ' ')
-			matrix[targetIdx] = append(matrix[targetIdx], []rune(path.TargetType)...)
+			lines[targetTypeLine] += space(len(path.Prefix)) + "| " + path.TargetType
+			targetTypeLine -= 2
 		} else {
-			for j := targetIdx; j >= targetPath; j-- {
-				matrix[j] = append(matrix[j], []rune(strings.Repeat(" ", len(path.Prefix)+padding))...)
+			for j := targetTypeLine; j >= targetLine; j-- {
+				lines[j] += space(len(path.Prefix) + padding)
 			}
 		}
 	}
 
 	buf := bytes.Buffer{}
-	for _, line := range matrix {
-		_, _ = fmt.Fprintln(&buf, strings.TrimSpace(string(line)))
+	for _, line := range lines {
+		_, _ = fmt.Fprintln(&buf, strings.TrimSpace(line))
 	}
 	fmt.Fprintln(&buf)
 	fmt.Fprint(&buf, err.Cause)
 	return buf.String()
+}
+
+func space(l int) string {
+	return strings.Repeat(" ", l)
 }

--- a/scenario/auto_map_ambigious.yml
+++ b/scenario/auto_map_ambigious.yml
@@ -30,8 +30,6 @@ error: |-
 
     | github.com/jmattheis/goverter/execution.Person
     |
-    |
-    |
     source.???
     target.Street
     |      |

--- a/scenario/auto_map_missing.yml
+++ b/scenario/auto_map_missing.yml
@@ -35,8 +35,6 @@ error: |-
     source.Abc
     target
     |
-    |
-    |
     | github.com/jmattheis/goverter/execution.FlatPerson
 
     "Abc" does not exist

--- a/scenario/auto_map_non_struct.yml
+++ b/scenario/auto_map_non_struct.yml
@@ -30,8 +30,6 @@ error: |-
     source.Address
     target
     |
-    |
-    |
     | github.com/jmattheis/goverter/execution.FlatPerson
 
     Address is not a struct or struct pointer

--- a/scenario/auto_map_pointer_error.yml
+++ b/scenario/auto_map_pointer_error.yml
@@ -36,8 +36,6 @@ error: |-
     |              |
     |              | string
     |
-    |
-    |
     | github.com/jmattheis/goverter/execution.FlatPerson
 
     TypeMismatch: Cannot convert *string to string

--- a/scenario/default_on_pointer_wrong_return_type.yml
+++ b/scenario/default_on_pointer_wrong_return_type.yml
@@ -33,10 +33,6 @@ error: |-
     source:NewOutput()
     target
     |
-    |
-    |
-    |
-    |
     | *github.com/jmattheis/goverter/execution.Output
 
     Method return type mismatches with target: github.com/jmattheis/goverter/execution.Wrong != github.com/jmattheis/goverter/execution.Output

--- a/scenario/default_on_struct_wrong_source_type.yml
+++ b/scenario/default_on_struct_wrong_source_type.yml
@@ -30,10 +30,6 @@ error: |-
     source:NewOutput(source)
     target
     |
-    |
-    |
-    |
-    |
     | github.com/jmattheis/goverter/execution.Output
 
     Method source type mismatches with conversion source: string != github.com/jmattheis/goverter/execution.Input

--- a/scenario/default_pointer_inconsistency_wrong_return.yml
+++ b/scenario/default_pointer_inconsistency_wrong_return.yml
@@ -31,10 +31,6 @@ error: |-
     source:NewOutput()
     target
     |
-    |
-    |
-    |
-    |
     | github.com/jmattheis/goverter/execution.Output
 
     Method return type mismatches with target: string != github.com/jmattheis/goverter/execution.Output

--- a/scenario/ignore_missing_map_extend.yml
+++ b/scenario/ignore_missing_map_extend.yml
@@ -27,8 +27,6 @@ error: |-
 
     | github.com/jmattheis/goverter/execution.Input
     |
-    |
-    |
     source.???
     target.Age
     |      |

--- a/scenario/ignore_missing_no_propergate.yml
+++ b/scenario/ignore_missing_no_propergate.yml
@@ -29,8 +29,6 @@ error: |-
     |
     |      | github.com/jmattheis/goverter/execution.NestedInput
     |      |
-    |      |
-    |      |
     source.Nested.???
     target.Nested.Age
     |      |      |

--- a/scenario/ignore_missing_unexported.yml
+++ b/scenario/ignore_missing_unexported.yml
@@ -21,8 +21,6 @@ error: |-
 
     | github.com/jmattheis/goverter/execution.Input
     |
-    |
-    |
     source.???
     target.age
     |      |

--- a/scenario/ignore_unexported_no_popergate.yml
+++ b/scenario/ignore_unexported_no_popergate.yml
@@ -29,8 +29,6 @@ error: |-
     |
     |      | github.com/jmattheis/goverter/execution.NestedInput
     |      |
-    |      |
-    |      |
     source.Nested.???
     target.Nested.internalState
     |      |      |

--- a/scenario/map_custom_error_with_wrong_return_type.yml
+++ b/scenario/map_custom_error_with_wrong_return_type.yml
@@ -24,18 +24,12 @@ error: |-
 
     | github.com/jmattheis/goverter/execution.Input
     |
-    |
-    |
     |            | func github.com/jmattheis/goverter/execution.DefaultName() string
     |            |
     |            |           | string
     |            |           |
     source.     :DefaultName()
     target.Score
-    |      |
-    |      |
-    |      |
-    |      |
     |      |
     |      | int
     |

--- a/scenario/map_custom_error_with_wrong_return_type2.yml
+++ b/scenario/map_custom_error_with_wrong_return_type2.yml
@@ -33,10 +33,6 @@ error: |-
     source.Name :DefaultName()
     target.Score
     |      |
-    |      |
-    |      |
-    |      |
-    |      |
     |      | int
     |
     | github.com/jmattheis/goverter/execution.Output

--- a/scenario/map_identity_pointer_source_error.yml
+++ b/scenario/map_identity_pointer_source_error.yml
@@ -35,10 +35,6 @@ error: |-
     source.        :ToFullName(source)
     target.FullName
     |      |
-    |      |
-    |      |
-    |      |
-    |      |
     |      | string
     |
     | github.com/jmattheis/goverter/execution.APIPerson

--- a/scenario/map_identity_wrong_source_type.yml
+++ b/scenario/map_identity_wrong_source_type.yml
@@ -33,10 +33,6 @@ error: |-
     source.     :Identity(source)
     target.Score
     |      |
-    |      |
-    |      |
-    |      |
-    |      |
     |      | int
     |
     | github.com/jmattheis/goverter/execution.Output

--- a/scenario/map_nested_missing_field.yml
+++ b/scenario/map_nested_missing_field.yml
@@ -32,12 +32,6 @@ error: |-
     source.Nested.Name.Oops
     target
     |
-    |
-    |
-    |
-    |
-    |
-    |
     | github.com/jmattheis/goverter/execution.Output
 
     Cannot access 'Oops' on int.

--- a/scenario/map_nested_pointer_type_mismatch.yml
+++ b/scenario/map_nested_pointer_type_mismatch.yml
@@ -32,8 +32,6 @@ error: |-
     |             |
     |             | string
     |
-    |
-    |
     | github.com/jmattheis/goverter/execution.Output
 
     TypeMismatch: Cannot convert *string to string

--- a/scenario/map_nested_type_missmatch.yml
+++ b/scenario/map_nested_type_missmatch.yml
@@ -32,8 +32,6 @@ error: |-
     |             |
     |             | string
     |
-    |
-    |
     | github.com/jmattheis/goverter/execution.Output
 
     TypeMismatch: Cannot convert int to string

--- a/scenario/map_nested_with_custom_error.yml
+++ b/scenario/map_nested_with_custom_error.yml
@@ -44,15 +44,7 @@ error: |-
     source.A.B.Relative:ToAbsolute(source)
     target    .Absolute
     |          |
-    |          |
-    |          |
-    |          |
-    |          |
     |          | string
-    |
-    |
-    |
-    |
     |
     | github.com/jmattheis/goverter/execution.Output
 

--- a/scenario/map_with_custom_error.yml
+++ b/scenario/map_with_custom_error.yml
@@ -34,10 +34,6 @@ error: |-
     source.Relative:Enhance(source)
     target.Absolute
     |      |
-    |      |
-    |      |
-    |      |
-    |      |
     |      | string
     |
     | github.com/jmattheis/goverter/execution.Output

--- a/scenario/match_ignore_case_no_propagate.yml
+++ b/scenario/match_ignore_case_no_propagate.yml
@@ -30,8 +30,6 @@ error: |-
     |
     |      | github.com/jmattheis/goverter/execution.InputNested
     |      |
-    |      |
-    |      |
     source.Nested.???
     target.Nested.Id
     |      |      |

--- a/scenario/match_ignore_case_unresolved_ambiguity.yml
+++ b/scenario/match_ignore_case_unresolved_ambiguity.yml
@@ -21,8 +21,6 @@ error: |-
 
     | github.com/jmattheis/goverter/execution.Input
     |
-    |
-    |
     source.???
     target.Myid
     |      |

--- a/scenario/struct_missing_field.yml
+++ b/scenario/struct_missing_field.yml
@@ -20,8 +20,6 @@ error: |-
 
     | github.com/jmattheis/goverter/execution.Input
     |
-    |
-    |
     source.???
     target.Age
     |      |

--- a/scenario/struct_missing_mapped_field.yml
+++ b/scenario/struct_missing_mapped_field.yml
@@ -26,8 +26,6 @@ error: |-
     source.Name3
     target
     |
-    |
-    |
     | github.com/jmattheis/goverter/execution.Output
 
     Cannot find the mapped field on the source entry: "Name3" does not exist.

--- a/scenario/struct_missing_mapped_nested_field.yml
+++ b/scenario/struct_missing_mapped_nested_field.yml
@@ -32,10 +32,6 @@ error: |-
     source.Nested.Name3
     target
     |
-    |
-    |
-    |
-    |
     | github.com/jmattheis/goverter/execution.Output
 
     Cannot find the mapped field on the source entry: "Name3" does not exist.

--- a/scenario/type_mismatch_nested.yml
+++ b/scenario/type_mismatch_nested.yml
@@ -48,12 +48,6 @@ error: |-
     |                          |
     |                          | *string
     |
-    |
-    |
-    |
-    |
-    |
-    |
     | github.com/jmattheis/goverter/execution.Output
 
     TypeMismatch: Cannot convert time.Time to string

--- a/scenario/unexported_error.yml
+++ b/scenario/unexported_error.yml
@@ -22,8 +22,6 @@ error: |-
 
     | github.com/jmattheis/goverter/execution.Input
     |
-    |
-    |
     source.???
     target.name
     |      |

--- a/scenario/use_zerovalue_on_pointer_inconsistency_value_type_mismatch.yml
+++ b/scenario/use_zerovalue_on_pointer_inconsistency_value_type_mismatch.yml
@@ -28,8 +28,6 @@ error: |-
     source.FirstName*
     target.FirstName
     |      |
-    |      |
-    |      |
     |      | int
     |
     | github.com/jmattheis/goverter/execution.APIPerson


### PR DESCRIPTION
Old:
```
Error while creating converter method:
    func (github.com/jmattheis/goverter/execution.Converter).Convert(source github.com/jmattheis/goverter/execution.Input) github.com/jmattheis/goverter/execution.Output

| github.com/jmattheis/goverter/execution.Input
|
|
|
|            | func github.com/jmattheis/goverter/execution.DefaultName() string
|            |
|            |           | string
|            |           |
source.     :DefaultName()
target.Score
|      |
|      |
|      |
|      |
|      |
|      | int
|
| github.com/jmattheis/goverter/execution.Output

Method return type mismatches with target: string != int
```

New:
```
Error while creating converter method:
    func (github.com/jmattheis/goverter/execution.Converter).Convert(source github.com/jmattheis/goverter/execution.Input) github.com/jmattheis/goverter/execution.Output

| github.com/jmattheis/goverter/execution.Input
|
|            | func github.com/jmattheis/goverter/execution.DefaultName() string
|            |
|            |           | string
|            |           |
source.     :DefaultName()
target.Score
|      |
|      | int
|
| github.com/jmattheis/goverter/execution.Output

Method return type mismatches with target: string != int
```