### PR TITLE
fixed getting output dir

### DIFF
--- a/generator/filemanager.go
+++ b/generator/filemanager.go
@@ -64,5 +64,10 @@ func getOutputDir(c *config.Converter, cwd string) string {
 	if strings.HasPrefix(c.OutputFile, "@cwd/") {
 		return filepath.Join(cwd, strings.TrimPrefix(c.OutputFile, "@cwd/"))
 	}
+
+	if strings.HasPrefix(c.OutputFile, "/") {
+		return c.OutputFile
+	}
+
 	return filepath.Join(filepath.Dir(c.FileSource), c.OutputFile)
 }

--- a/generator/filemanager.go
+++ b/generator/filemanager.go
@@ -65,7 +65,7 @@ func getOutputDir(c *config.Converter, cwd string) string {
 		return filepath.Join(cwd, strings.TrimPrefix(c.OutputFile, "@cwd/"))
 	}
 
-	if strings.HasPrefix(c.OutputFile, "/") {
+	if filepath.IsAbs(c.OutputFile) {
 		return c.OutputFile
 	}
 


### PR DESCRIPTION
if use output:file absolute path then gen file created not in this dir
goverter gen -g 'output:file /tmp/some_dir/generated.go'