### PR TITLE
docs: Added extra note on time.Time in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,6 +6,49 @@
 
 See [Guide: Struct](./guide/struct.md)
 
+## Skip conversion (aka shallow copy), e.g for time.Time
+
+Many structs like `time.Time` or `net/url.URL` are best to
+just copy instead of convert field-by-field.
+
+To resolve errors like these:
+
+```console
+$ goverter gen ./...
+Error while creating converter method:
+    /home/myuser/code/my-project/converters.go:9
+    func (my-project/main.Converter).ConvertFoo(source my-project/main.Source) my-project/main.Target
+        [source] my-project/main.Source
+        [target] my-project/main.Target
+
+| my-project/main.Source
+|
+|      | time.Time
+|      |
+source.CreatedAt.???
+target.CreatedAt.wall
+|      |         |
+|      |         | uint64
+|      |
+|      | time.Time
+|
+| my-project/main.Target
+
+Cannot set value for unexported field "wall".
+
+See https://goverter.jmattheis.de/guide/unexported-field
+```
+
+You need to add a custom converter, such as:
+
+::: details Example (click me)
+::: code-group
+<<< @../../example/time/input.go
+<<< @../../example/time/generated/generated.go [generated/generated.go]
+:::
+
+See [Guide: Structs / Unexported field](./guide/unexported-field.md)
+
 ## TypeMismatch: Cannot convert interface{} to interface{}
 
 See below


### PR DESCRIPTION
Adds extra emphasis on how to deal with `time.Time`

I stumbled a bit on this when first learning goverter. I knew I saw somewhere when skimming the docs on how to deal with this, but couldn't find it when I had this issue. Kind of in frustration of not solving the issue I kept overlooking the "shallow copy" part that's in the middle of one of the docs pages. In the end I had to go scouting in the closed GitHub issues and eventually found someone mentioning this.

This PR just adds another mention of this in the FAQ so it's easier to find.
