### PR TITLE
docs: Added icon on external links

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -34,6 +34,7 @@ export default defineConfig({
         indexName: "goverter-jmattheis",
       },
     },
+    externalLinkIcon: true,
     nav: [
       { text: "Getting Started", link: "/guide/getting-started" },
       { text: "Settings", link: "/reference/settings" },

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,7 +11,7 @@
 1. [Guide: Install Goverter](./install.md)
 
 1. Create your converter interface and mark it with a comment containing
-   [`goverter:converter`](https://goverter.jmattheis.de/reference/converter)
+   [`goverter:converter`](../reference/converter.md)
 
     ::: code-group
     ```go [input.go]


### PR DESCRIPTION
I was browsing the docs and got confused by some links sending me to wikipedia thought "hmm I wish the docs had that icon thing to show which links are external links". A quick google showed that vitepress has this built in.

Before:

![image](https://github.com/user-attachments/assets/e4d6abdc-589c-4cbf-9fa9-4b7ce6a07469)

After:

![image](https://github.com/user-attachments/assets/0943a9a9-c533-4c41-bb3c-05e6ea1abe4b)

---

It would be much nicer to have something like the favicon to the page next to the link, you know like this:

![image](https://github.com/user-attachments/assets/863e1ca3-1949-42ad-9ff7-05fbea8b900a)

(<https://css-tricks.com/favicons-next-to-external-links/>)

but I couldn't find a quick solution for that with vitepress online and didn't have the energy to dig much further so I just settled for the built in feature.